### PR TITLE
Add Github Actions to automatic deployment of the wiki.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./public

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # XS-Leaks Wiki
 
+## Build Process
 
-## Build locally
+### Build locally
 
 1. Install the [Hugo Framework](https://gohugo.io/getting-started/installing/) **extended** version > 0.68
 2. Clone this repo
 3. Run `hugo server --minify` in root directory 
 4. Open your browser and go to http://localhost:1313 (or as indicated by hugo output)
 
-## Generate static files
+### Generate static files
 
 1. Run `hugo --buildDrafts`
+
+## Automatic Deployment
+
+This repository uses [Github Actions](https://github.com/features/actions) to automatically build and publish a static version of the XS-Leaks Wiki once a Pull Request is accepted. To bring Github Pages automation into Github Actions we use [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages). To automatically build a website with the Hugo Framework, we use [actions-hugo](https://github.com/peaceiris/actions-hugo)
+
+The strategy used to give the workflow access to this repository uses a [deploy_key](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-ssh-private-key-deploy_key) which is privately set in this repository.


### PR DESCRIPTION
The followed configuration process was [this one](https://github.com/peaceiris/actions-gh-pages) for github pages and [this one](https://github.com/peaceiris/actions-hugo) for hugo stuff. A deploy key was added in the org secrets, and everything should be automatic. We can *later* add scripts to verify the wiki's integrity.
All PR's and pushes to master will be verified whether hugo is able to run: mostly it verifies if there are no broken links, etc. 

This feature is particularly important once we start accepting community contributions. 

**Important note to future maintainers:** I won't save the private key, so if the time comes, you should create a new deploy key and ignore the current one which is only useful for the deployment process.