### PR TITLE
Add Hybrid Timing Attacks Article + sandboxed frame timing

### DIFF
--- a/content/docs/attacks/timing-attacks/hybrid-timing.md
+++ b/content/docs/attacks/timing-attacks/hybrid-timing.md
@@ -1,0 +1,30 @@
++++
+title = "Hybrid Timing"
+description = ""
+date = "2020-07-21"
+category = "attacks"
+attacks = [
+    "dom property",
+]
+defenses = [
+    "same-site cookies",
+    "sec-fetch metadata",
+]
+menu = "main"
++++
+
+
+dsadsadasdsaasd
+
+## Defense
+
+| Attack Alternative  | [Same-Site Cookies]({{< ref "../../defenses/opt-in/same-site-cookies.md" >}})  | [Fetch Metadata]({{< ref "../../defenses/opt-in/fetch-metadata.md" >}})  | [Cross-Origin-Opener-Policy]({{< ref "../../defenses/opt-in/coop.md" >}})  |  [Framing Protections]({{< ref "../../defenses/opt-in/xfo.md" >}}) |
+|:-------------------:|:------------------:|:---------------:|:-----:|:--------------------:|
+| Modern Timing Attacks              |         ✔️         |      ✔️         |  ❌   |          ❌         |
+| Frame Timing |         ✔️       |      ✔️         |  ❌   |          ✔️
+| Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ✔️   |          ❌         |
+| Timeless Timing  |         ✔️        |      ✔️         |  ❌   |          ❌         |
+
+[^1]: Exposing Private Information by Timing Web Applications. [link](https://crypto.stanford.edu/~dabo/papers/webtiming.pdf)
+[^2]: The Clock is Still Ticking: Timing Attacks in the Modern Web - Section 4.3.3, [link](https://tom.vg/papers/timing-attacks_ccs2015.pdf)
+[^3]: Timeless Timing Attacks: Exploiting Concurrency to Leak Secrets over Remote Connections. [link](https://www.usenix.org/system/files/sec20-van_goethem.pdf)

--- a/content/docs/attacks/timing-attacks/hybrid-timing.md
+++ b/content/docs/attacks/timing-attacks/hybrid-timing.md
@@ -13,18 +13,32 @@ defenses = [
 menu = "main"
 +++
 
+Hybrid Timing Attacks allow attackers to measure a combination of factors that influence the final timing measurement. These factors can be:
 
-dsadsadasdsaasd
+- [Network Timing](https://TODO).
+- Time to parse the document.
+- Retrieve and load subresources.
+- [Execution Timing](https://TODO).
+
+Some of the factors differ in value depending on the application. This means that [Network Timing](https://TODO) might be more observable in pages with more backend processing while [Execution Timing](https://TODO) can be more observable in applications processing and displaying data within the browser. Attackers can also eliminate some of the factors of the equation to obtain better measurements, for example, one could preload all the subresources by embedding the page as an iframe (forcing the browser to cache them) and do a second measurement which will exclude any delay introduced by the retrieval of those subresources.
+
+###  Frame Timing Attacks (Hybrid)
+
+If a page does not set [Framing Protections](https://TODO), an attacker can obtain a hybrid measurement that considers all the factors. This attack is similar to the [Network-based Attack](https://TODO-frame-timing-attacks-network), but when the resource arrives at the browser the page is rendered and executed by the browser (subresources retrieved and JavaScript executed). In this scenario, the `onload` event only triggers when the page fully loads.
+
+```html
+<iframe name=f id=g></iframe>
+<script>
+before = performance.now();
+f.location = 'https://target.page';
+g.onerror = g.onload = ()=>{
+    console.log('time was', performance.now() - before)
+};
+</script>
+```
 
 ## Defense
 
 | Attack Alternative  | [Same-Site Cookies]({{< ref "../../defenses/opt-in/same-site-cookies.md" >}})  | [Fetch Metadata]({{< ref "../../defenses/opt-in/fetch-metadata.md" >}})  | [Cross-Origin-Opener-Policy]({{< ref "../../defenses/opt-in/coop.md" >}})  |  [Framing Protections]({{< ref "../../defenses/opt-in/xfo.md" >}}) |
-|:-------------------:|:------------------:|:---------------:|:-----:|:--------------------:|
-| Modern Timing Attacks              |         ✔️         |      ✔️         |  ❌   |          ❌         |
-| Frame Timing |         ✔️       |      ✔️         |  ❌   |          ✔️
-| Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ✔️   |          ❌         |
-| Timeless Timing  |         ✔️        |      ✔️         |  ❌   |          ❌         |
-
-[^1]: Exposing Private Information by Timing Web Applications. [link](https://crypto.stanford.edu/~dabo/papers/webtiming.pdf)
-[^2]: The Clock is Still Ticking: Timing Attacks in the Modern Web - Section 4.3.3, [link](https://tom.vg/papers/timing-attacks_ccs2015.pdf)
-[^3]: Timeless Timing Attacks: Exploiting Concurrency to Leak Secrets over Remote Connections. [link](https://www.usenix.org/system/files/sec20-van_goethem.pdf)
+|:----------------------:|:------------------:|:---------------:|:-----:|:--------------------:|
+| Frame Timing (Hybrid)  |         ✔️       |      ✔️       |  ❌   |          ✔️          |

--- a/content/docs/attacks/timing-attacks/hybrid-timing.md
+++ b/content/docs/attacks/timing-attacks/hybrid-timing.md
@@ -15,10 +15,10 @@ menu = "main"
 
 Hybrid Timing Attacks allow attackers to measure a combination of factors that influence the final timing measurement. These factors can be:
 
-- [Network Timing](https://TODO).
-- Time to parse the document.
+- [Network](https://TODO).
+- Parsing.
 - Retrieve and load subresources.
-- [Execution Timing](https://TODO).
+- [Execution](https://TODO).
 
 Some of the factors differ in value depending on the application. This means that [Network Timing](https://TODO) might be more observable in pages with more backend processing while [Execution Timing](https://TODO) can be more observable in applications processing and displaying data within the browser. Attackers can also eliminate some of the factors of the equation to obtain better measurements, for example, one could preload all the subresources by embedding the page as an iframe (forcing the browser to cache them) and do a second measurement which will exclude any delay introduced by the retrieval of those subresources.
 

--- a/content/docs/attacks/timing-attacks/hybrid-timing.md
+++ b/content/docs/attacks/timing-attacks/hybrid-timing.md
@@ -24,7 +24,7 @@ Some of the factors differ in value depending on the application. This means tha
 
 ###  Frame Timing Attacks (Hybrid)
 
-If a page does not set [Framing Protections](https://TODO), an attacker can obtain a hybrid measurement that considers all the factors. This attack is similar to the [Network-based Attack](https://TODO-frame-timing-attacks-network), but when the resource arrives at the browser the page is rendered and executed by the browser (subresources retrieved and JavaScript executed). In this scenario, the `onload` event only triggers when the page fully loads.
+If a page does not set [Framing Protections](https://TODO), an attacker can obtain a hybrid measurement that considers all the factors. This attack is similar to the [Network-based Attack](https://TODO-frame-timing-attacks-network), but when the resource is retrieved the page is rendered and executed by the browser (subresources fetched and JavaScript executed). In this scenario, the `onload` event only triggers when the page fully loads.
 
 ```html
 <iframe name=f id=g></iframe>

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -112,7 +112,7 @@ This attack is limited to specific versions of HTTP and joint scenarios. It make
 | Modern Timing Attacks              |         ✔️         |      ✔️         |  ❌   |          ❌         |
 | Frame Timing (Network) |         ✔️       |      ✔️         |  ❌   |          -
 | Frame Timing (Sandbox) |         ✔️       |      ✔️         |  ❌   |          -
-| Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ✔️   |          ❌         |
+| Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ❌   |          ❌         |
 | Timeless Timing  |         ✔️        |      ✔️         |  ❌   |          ❌         |
 
 [^1]: Exposing Private Information by Timing Web Applications. [link](https://crypto.stanford.edu/~dabo/papers/webtiming.pdf)

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -42,7 +42,7 @@ let request_time = performance.now() - before
 
 ## Frame Timing Attacks (Network)
 
-If the target page enforces [Framing Protections](https://TODO), embedding it as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how to achieve this by starting a [clock](https://TODO), embedding the page as an `iframe` (request is started), and wait for the `onload` event to be triggered (request completed).
+If the target page enforces [Framing Protections](https://TODO), embedding it as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how to achieve this by starting a [clock](https://TODO), embedding the page as an `iframe` (request is started), and wait for the `onload` event to be triggered which means the request completed. In this scenario when the request completes the browser does not render the fetched resource because of the protection.
 
 ```javascript
 begin = performance.now();

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -30,7 +30,7 @@ This side-channel allows attackers to infer information from a cross-site reques
 Learn more about the different types of clocks in the [Clocks Article]({{< ref "clocks.md" >}}).
 {{< /hint >}}
 
-### Modern Web Timing Attacks
+## Modern Web Timing Attacks
 
 The [performance.now()]({{< ref "clocks.md#performancenow" >}}) API can be used to measure how much time it takes to perform a request.
 
@@ -40,7 +40,7 @@ await fetch('https://target-website.com',{'mode':'no-cors','credentials':'includ
 let request_time = performance.now() - before
 ```
 
-### Frame Timing Attacks (Network)
+## Frame Timing Attacks (Network)
 
 If the target page enforces [Framing Protections](https://TODO), embedding it as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how to achieve this by starting a [clock](https://TODO), embedding the page as an `iframe` (request is started), and wait for the `onload` event to be triggered (request completed).
 
@@ -53,12 +53,12 @@ start = performance.now();
 x.onload = () => console.log(performance.now() - begin)
 ```
 
-### Sandboxed Frame Timing Attacks
+## Sandboxed Frame Timing Attacks
 
 When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution thus preventing subresources from loading.
 
 
-### Cross-window Timing Attacks
+## Cross-window Timing Attacks
 
 An attacker can also measure the network timing of a page by navigating the victim away with `window.open` and wait for the `window` to start loading. The snippet below shows how to make this measurement and works as follows:
 
@@ -87,7 +87,7 @@ begin = performance.now();
 w = open('//mail.com/search?q=foo');
 {{< / highlight >}}
 
-### Timeless Timing Attacks
+## Timeless Timing Attacks
 
 Other attacks do not consider the notion of time to perform a timing attack [^3]. Timeless attacks consist of fitting two `HTTP` requests in a single packet, the baseline and the attacked request, to guarantee they arrive at the same time to the server. The server *will* process the requests concurrently, and return a response based on their execution time as soon as possible. One of the two requests will arrive first, allowing the attacker to get the timing difference by comparing both requests.
 

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -60,7 +60,7 @@ When a page sets [Framing Protections](https://TODO), an attacker can obtain a p
 
 ## Cross-window Timing Attacks
 
-An attacker can also measure the network timing of a page by navigating the victim away with `window.open` and wait for the `window` to start loading. The snippet below shows how to make this measurement and works as follows:
+An attacker can also measure the network timing of a page by opening a new window with `window.open` and wait for the `window` to start loading. The snippet below shows how to make this measurement and works as follows:
 
 1. The attacker creates an infinite loop of `postMessage` broadcasts to itself while opening a window to the target website (lines 15, 2, 7). The clock is started (line 14).
 2. When the window is created, its location [will be `about:blank`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) until the target page starts loading.

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -55,7 +55,7 @@ x.onload = () => console.log(performance.now() - begin)
 
 ## Sandboxed Frame Timing Attacks
 
-When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution thus preventing some subresources from loading.
+When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution and prevent some subresources from loading.
 
 
 ## Cross-window Timing Attacks

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -13,7 +13,7 @@ defenses = [
 menu = "main"
 +++
 
-Network Timing side-channels have been present on the web since its beginning [^1]. These attacks achieved different levels of impact over time, gaining new attention when browsers started shipping high precision timers like [performance.now()]({{< ref "clocks.md#performancenow" >}}).
+Network Timing side-channels have been present on the web since its beginning [^1] [^4]. These attacks achieved different levels of impact over time, gaining new attention when browsers started shipping high precision timers like [performance.now()]({{< ref "clocks.md#performancenow" >}}).
 
 To obtain timing measurements attackers must use a [clock]({{< ref "clocks.md" >}}), either an implicit or explicit one. These clocks are usually interchangeable and only vary in accuracy and availability. For simplicity, this article will only address the `performance.now()` API, an explicit clock present in all modern browsers.
 
@@ -60,7 +60,7 @@ When a website sets [Framing Protections](https://TODO), an attacker can measure
 
 ### Cross-window Timing Attacks
 
-If a page sets [Framing Protections](https://TODO) an attacker can still measure a page full load (i.e including subresources) by navigating the victim with `window.open`. This is due to the fact that opening windows is not affected by framing protections.
+If a page sets [Framing Protections](https://TODO) an attacker can still measure a page full load by navigating the victim with `window.open`. This is due to the fact that opening windows is not affected by framing protections.
 
 The snippet below shows how make this measurement and works as follows:
 
@@ -113,8 +113,10 @@ This attack is limited to specific versions of HTTP and joint scenarios. It make
 | Frame Timing (Network) |         ✔️       |      ✔️         |  ❌   |          -
 | Frame Timing (Sandbox) |         ✔️       |      ✔️         |  ❌   |          -
 | Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ❌   |          ❌         |
-| Timeless Timing  |         ✔️        |      ✔️         |  ❌   |          ❌         |
+| Timeless Timing  |         ✔️        |      ❓         |  ❌   |          ❌         |
 
-[^1]: Exposing Private Information by Timing Web Applications. [link](https://crypto.stanford.edu/~dabo/papers/webtiming.pdf)
+[^1]: Exposing Private Information by Timing Web Applications, [link](https://crypto.stanford.edu/~dabo/papers/webtiming.pdf)
 [^2]: The Clock is Still Ticking: Timing Attacks in the Modern Web - Section 4.3.3, [link](https://tom.vg/papers/timing-attacks_ccs2015.pdf)
-[^3]: Timeless Timing Attacks: Exploiting Concurrency to Leak Secrets over Remote Connections. [link](https://www.usenix.org/system/files/sec20-van_goethem.pdf)
+[^3]: Timeless Timing Attacks: Exploiting Concurrency to Leak Secrets over Remote Connections, [link](https://www.usenix.org/system/files/sec20-van_goethem.pdf)
+[^4]: Cross-domain search timing, [link](https://scarybeastsecurity.blogspot.com/2009/12/cross-domain-search-timing.html)
+

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -17,12 +17,12 @@ Network Timing side-channels have been present on the web since its beginning [^
 
 To obtain timing measurements attackers must use a [clock]({{< ref "clocks.md" >}}), either an implicit or explicit one. These clocks are usually interchangeable and only vary in accuracy and availability. For simplicity, this article will only address the `performance.now()` API, an explicit clock present in all modern browsers.
 
-This side-channel allows attackers to infer information from a cross-site request based on how much time it takes to complete a request [^2]. The timing measurement may vary based on a user state and it's usually connected to:
+This side-channel allows attackers to infer information from a cross-site request based on how much time it takes to complete that request [^2]. The network timing measurement may vary based on a user state and it's usually connected to:
 
-- Resource Size
-- The computation time in the backend
-- Amount of sub-resources
-- [Cache status](https://TODO)
+- Resource Size.
+- The computation time in the backend.
+- Amount of sub-resources.
+- [Cache status](https://TODO).
 
 <!--TODO(manuelvsousa): Add cross reference to cache attacks in the wiki -->
 
@@ -36,24 +36,27 @@ The [performance.now()]({{< ref "clocks.md#performancenow" >}}) API can be used 
 
 ```javascript
 let before = performance.now()
-await fetch("https://target-website.com")
+await fetch('https://target-website.com',{'mode':'no-cors','credentials':'include'})
 let request_time = performance.now() - before
 ```
 
-### Frame Timing Attacks
+### Frame Timing (Network)
 
-This mechanism allows an attacker to measure a page full load which includes subresources. If [Framing Protections](https://TODO) are in place, only the network request can be measured since its subresources are not fetched.
+If the target website enforces [Framing Protections](https://TODO), embedding said website as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how an attacker can achieve this by starting a [clock](https://TODO), embedding the website as an iframe (request is started), and wait for the `onload` event to be fired (request completed).
 
-```html
-<iframe name=f id=g></iframe>
-<script>
-before = performance.now();
-f.location = 'https://target-website.com';
-g.onerror = g.onload = ()=>{
-    console.log('time was', performance.now() - before)
-};
-</script>
+```javascript
+begin = performance.now();
+var x = document.createElement('iframe');
+x.src = "https://target.page";
+document.body.appendChild(x);
+start = performance.now();
+x.onload = () => console.log(performance.now() - begin)
 ```
+
+### Frame Timing (Sandbox)
+
+When a website sets [Framing Protections](https://TODO), an attacker can measure a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the iframe. This attribute will block all JavaScript execution thus preventing subresources from loading.
+
 
 ### Cross-window Timing Attacks
 

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -55,7 +55,7 @@ x.onload = () => console.log(performance.now() - begin)
 
 ## Sandboxed Frame Timing Attacks
 
-When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution thus preventing subresources from loading.
+When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution thus preventing some subresources from loading.
 
 
 ## Cross-window Timing Attacks

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -110,7 +110,8 @@ This attack is limited to specific versions of HTTP and joint scenarios. It make
 | Attack Alternative  | [Same-Site Cookies]({{< ref "../../defenses/opt-in/same-site-cookies.md" >}})  | [Fetch Metadata]({{< ref "../../defenses/opt-in/fetch-metadata.md" >}})  | [Cross-Origin-Opener-Policy]({{< ref "../../defenses/opt-in/coop.md" >}})  |  [Framing Protections]({{< ref "../../defenses/opt-in/xfo.md" >}}) |
 |:-------------------:|:------------------:|:---------------:|:-----:|:--------------------:|
 | Modern Timing Attacks              |         ✔️         |      ✔️         |  ❌   |          ❌         |
-| Frame Timing |         ✔️       |      ✔️         |  ❌   |          ✔️
+| Frame Timing (Network) |         ✔️       |      ✔️         |  ❌   |          -
+| Frame Timing (Sandbox) |         ✔️       |      ✔️         |  ❌   |          -
 | Cross-window Timing  |         ✔️ (if Strict)       |      ✔️         |  ✔️   |          ❌         |
 | Timeless Timing  |         ✔️        |      ✔️         |  ❌   |          ❌         |
 

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -55,7 +55,7 @@ x.onload = () => console.log(performance.now() - begin)
 
 ## Sandboxed Frame Timing Attacks
 
-When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution and prevent some subresources from loading.
+When a page sets [Framing Protections](https://TODO), an attacker can obtain an almost pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution and prevent some subresources from loading.
 
 
 ## Cross-window Timing Attacks

--- a/content/docs/attacks/timing-attacks/network-timing.md
+++ b/content/docs/attacks/timing-attacks/network-timing.md
@@ -40,9 +40,9 @@ await fetch('https://target-website.com',{'mode':'no-cors','credentials':'includ
 let request_time = performance.now() - before
 ```
 
-### Frame Timing (Network)
+### Frame Timing Attacks (Network)
 
-If the target website enforces [Framing Protections](https://TODO), embedding said website as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how an attacker can achieve this by starting a [clock](https://TODO), embedding the website as an iframe (request is started), and wait for the `onload` event to be fired (request completed).
+If the target page enforces [Framing Protections](https://TODO), embedding it as an `iframe` allows an attacker to obtain a network timing measurement. The example below shows how to achieve this by starting a [clock](https://TODO), embedding the page as an `iframe` (request is started), and wait for the `onload` event to be triggered (request completed).
 
 ```javascript
 begin = performance.now();
@@ -53,16 +53,14 @@ start = performance.now();
 x.onload = () => console.log(performance.now() - begin)
 ```
 
-### Frame Timing (Sandbox)
+### Sandboxed Frame Timing Attacks
 
-When a website sets [Framing Protections](https://TODO), an attacker can measure a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the iframe. This attribute will block all JavaScript execution thus preventing subresources from loading.
+When a page sets [Framing Protections](https://TODO), an attacker can obtain a pure network measurement by including the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) attribute in the `iframe`. This attribute will block all JavaScript execution thus preventing subresources from loading.
 
 
 ### Cross-window Timing Attacks
 
-If a page sets [Framing Protections](https://TODO) an attacker can still measure a page full load by navigating the victim with `window.open`. This is due to the fact that opening windows is not affected by framing protections.
-
-The snippet below shows how make this measurement and works as follows:
+An attacker can also measure the network timing of a page by navigating the victim away with `window.open` and wait for the `window` to start loading. The snippet below shows how to make this measurement and works as follows:
 
 1. The attacker creates an infinite loop of `postMessage` broadcasts to itself while opening a window to the target website (lines 15, 2, 7). The clock is started (line 14).
 2. When the window is created, its location [will be `about:blank`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) until the target page starts loading.
@@ -103,8 +101,6 @@ The original research needs to be adapted to work in a browser since it handles 
 This attack is limited to specific versions of HTTP and joint scenarios. It makes certain assumptions and has requirements regarding server behaviors.
 {{< /hint >}}
 
-<!--TODO(manuelvsousa): Add case scenarios -->
-
 ## Defense
 
 | Attack Alternative  | [Same-Site Cookies]({{< ref "../../defenses/opt-in/same-site-cookies.md" >}})  | [Fetch Metadata]({{< ref "../../defenses/opt-in/fetch-metadata.md" >}})  | [Cross-Origin-Opener-Policy]({{< ref "../../defenses/opt-in/coop.md" >}})  |  [Framing Protections]({{< ref "../../defenses/opt-in/xfo.md" >}}) |
@@ -119,4 +115,3 @@ This attack is limited to specific versions of HTTP and joint scenarios. It make
 [^2]: The Clock is Still Ticking: Timing Attacks in the Modern Web - Section 4.3.3, [link](https://tom.vg/papers/timing-attacks_ccs2015.pdf)
 [^3]: Timeless Timing Attacks: Exploiting Concurrency to Leak Secrets over Remote Connections, [link](https://www.usenix.org/system/files/sec20-van_goethem.pdf)
 [^4]: Cross-domain search timing, [link](https://scarybeastsecurity.blogspot.com/2009/12/cross-domain-search-timing.html)
-

--- a/content/docs/defenses/opt-in/xfo.md
+++ b/content/docs/defenses/opt-in/xfo.md
@@ -10,6 +10,8 @@ menu = "main"
 
 A considerable number of XS-Leaks relies on some properties of `iframes`. If an attacker is unable to embed the contents of a page as an `iframe` then the attack may no longer be possible. To mitigate XS-Leaks which rely on this object, pages can forbid or select which origins can embed them. This is possible by using the [X-Frame-Options Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) or the [CSP frame-ancestors directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
 
+Since a website enforcing Framing Protections can't be embed from an attacker origin, the website is not rendered and the JavaScript does not run. Therefore, all of its subresources (images, JS or CSS) are not retrieved by the browser.
+
 {{< hint warning >}}
 [X-Frame-Options Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) is obsolete and was replaced by the [CSP frame-ancestors directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
 {{< /hint >}}
@@ -20,7 +22,7 @@ This protection is very effective against XS-Leaks which rely on `iframes` and c
 
 ## Deployment
 
-Deploying framing protections is usually straightforward as many applications do not require to be embedded cross-origin in an iframe. Check out this [web.dev](https://web.dev/same-origin-policy/) article to learn more about the the advantages of this header.
+Deploying framing protections is usually straightforward as many applications do not require to be embedded cross-origin in an iframe. Check out this [web.dev](https://web.dev/same-origin-policy/) article to learn more about the advantages of this header.
 
 ## XS-Leaks Mitigation Overview
 
@@ -28,7 +30,7 @@ Deploying framing protections is usually straightforward as many applications do
 |:-----------------------------------------------------------------:|:------------------------:|:-------------------:
 | [Frame Counting]({{< ref "../../attacks/frame-counting.md" >}})   |         ✔️               |         ❌
 | [Navigations]({{< ref "../../attacks/navigations.md" >}})         |         ✔️               |         ❌
-| [ID Leaks]({{< ref "../../attacks/id-attribute.md" >}})               |         ✔️               |         ❌
+| [ID Leaks]({{< ref "../../attacks/id-attribute.md" >}})           |         ✔️               |         ❌
 
 ### Table Caption
 

--- a/content/docs/defenses/opt-in/xfo.md
+++ b/content/docs/defenses/opt-in/xfo.md
@@ -10,7 +10,7 @@ menu = "main"
 
 A considerable number of XS-Leaks relies on some properties of `iframes`. If an attacker is unable to embed the contents of a page as an `iframe` then the attack may no longer be possible. To mitigate XS-Leaks which rely on this object, pages can forbid or select which origins can embed them. This is possible by using the [X-Frame-Options Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) or the [CSP frame-ancestors directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
 
-Since a website enforcing Framing Protections can't be embed from an attacker origin, the website is not rendered and the JavaScript does not run. Therefore, all of its subresources (images, JS or CSS) are not retrieved by the browser.
+Since a website enforcing Framing Protections can't be embedded from an attacker origin, the website is not rendered and the JavaScript does not run. Therefore, all of its subresources (images, JS or CSS) are not retrieved by the browser.
 
 {{< hint warning >}}
 [X-Frame-Options Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) is obsolete and was replaced by the [CSP frame-ancestors directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).


### PR DESCRIPTION
This is logic separation with a bit more context, in Timing Attacks section. Also adds:

- Fix Network Timing Defense Table
- Add new 1 line explanation to XFO
- Markdown level fixes

This PR solves issue #14 