### PR TITLE
Improved the text for a front page of the wiki

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -52,16 +52,13 @@ The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes
 We can distinguish different sources of XS-Leaks, such as:
 
 -   Browser APIs 
-
-    -   For example: Frame Counting and Timing Attacks
+    -   For example: [Frame Counting]({{< ref "frame-counting.md" >}}) and [Timing Attacks]({{< ref "timing-attacks.md" >}})
 
 -   Browser Implementation Details and Bugs
-
-    -   For example: Connection Pooling and typeMustMatch
+    -   For example: [Connection Pooling]({{< ref "./docs/attacks/timing-attacks/connection-pool.md" >}}) and [typeMustMatch]({{< ref "./docs/attacks/historical/content-type.md#typemustmatch" >}})
 
 -   Hardware Bugs
-
-    -   For example: Speculative Execution Attacks
+    -   For example: Speculative Execution Attacks [^spectre]
 
 ## A little bit of history
 
@@ -80,3 +77,4 @@ This wiki is meant to both introduce readers to XS-Leaks and serve as a referenc
 [^hard-to-fix]: It is challenging to fix the root cause of XS-Leaks because in many cases doing so would break existing websites.
 [^old-wiki]: Browser Side Channels, [link](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels)
 [^xs-search-first]: Cross-Site Search Attacks, [link](https://446h.cybersec.fun/xssearch.pdf)
+[^spectre]: Meltdown and Spectre, [link](https://spectreattack.com/)

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ bookToc: false
 # XS-Leaks Wiki
 ## Overview
 
-Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF, XSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about the user. This is done by utilising a variety of features built into browsers. These features are often maintained to preserve backwards compatibility though sometimes new features are added to the browser despite an accepted risk of cross-site leaks [^STTF].
+Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF, XSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about them. This is done by utilising a variety of features built into browsers which are often maintained to preserve backwards compatibility. Though, sometimes new features are added to the browser despite an accepted risk of cross-site leaks [^STTF].
 
 
 ## The principle of an XS-Leak

--- a/content/_index.md
+++ b/content/_index.md
@@ -16,11 +16,11 @@ Websites interacting with each other is core to the behavior of the web. Browser
 
 These pieces of information usually have a binary form and are called oracles. These oracles usually answer with *YES* and *NO* to cleverly prepared questions. For example, such an oracle could be asked:
 
-> Does a word *existent* exist in the search results?
+> Does the word *existent* exist in the search results?
 
 In a vulnerable application, the above might be equivalent to:
 
-> Does a query *?query=existent* return HTTP200 status code while *?query=non-existent* does not?"
+> Does the query *?query=existent* return HTTP200 status code while the query *query=non-existent* does not?"
 
 The latter oracle could be formed from an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) XS-Leak and which could be abused by attackers to infer information about the user.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,32 +4,78 @@ type: docs
 bookToc: false
 ---
 
-# What are XS-Leaks?
+# XS-Leaks Wiki
+## Overview
 
-Cross-Site Leaks are a class of vulnerabilities that have been present on the web for a long time, gaining new attention at the end of 2018 when a formal name was assigned and a [repository](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels) of some of them was created. These vulnerabilities are Browser Side-channel Attacks and most of them exploit behaviors **inherent to the design of the web**, which increases the complexity around their mitigation.
+Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF, XSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about the user. This is done by utilising a variety of features built into browsers. These features are often maintained to preserve backwards compatibility though sometimes new features are added to the browser despite an accepted risk of cross-site leaks [^STTF].
 
-## Why are XS-Leaks Hard to fix?
 
-- The cause of most XS-Leaks is **inherent to the design of the web**. Applications can be vulnerable to some XS-Leaks without explicitly introducing them.
-- Unlike common vulnerabilities such as `XSS`, with very specific taxonomies and attack consequences, XS-Leaks are an aggregation of several attack vectors with different implications.
-- XS-Leaks are application behavior dependent, so their consequences can't be generalized.
-- Mitigating one XS-Leak can be irrelevant if all the others are possible to exploit. To be effective against most of them, applications must combine different types of [Defense Mechanisms]({{< ref "../docs/defenses/" >}}).
+## The principle of an XS-Leak
 
-## The Principle of XS-Leaks
+Websites interacting with each other is core to the behavior of the web. Browsers provide a wide variety of interfaces for such interaction between different web applications. These interfaces have a wide variety of security measures built on top to try to constrain websites behavior (e.g. the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)). XS-Leaks take advantage of small pieces of information that can leak during these interactions in order to infer sensitive information about users. 
 
-When `attacker.com` makes a request to `bank.com`, the browser will attach user cookies along with the request. The `Same-origin policy` is enforced and stop `attacker.com` from getting the contents of `bank.com`, and the principle of XS-Leaks is to go around this protection to **infer** Private Identifiable Information (PII) by watching the behavior of secondary events/channels (e.g Browser Cache, Request Timing).
+These pieces of information usually have a binary form and are called oracles. These oracles usually answer with *YES* and *NO* to cleverly prepared questions. For example, such an oracle could be asked:
 
-Leaked information is **always** application dependent, varies depending on the features of the application and how it behaves in specific situations.
+> Does a word *existent* exist in the search results?
 
-There are several types of XS-Leaks, and they have distinct origins:
+In a vulnerable application, the above might be equivalent to:
 
-- [`HTML` APIs]({{< ref "frame-counting.md" >}}) that allow attackers to access information about a page
-- [Browser Features]({{< ref "../docs/attacks/historical/stateful-browser-features.md" >}}) which unintendedly introduced XS-Leaks
-- [Browser Bugs]({{< ref "../docs/attacks/historical/Content-Type.md#typemustmatch" >}})
-- [Inherent Web Platform Features]({{< ref "frame-counting.md" >}}) (or a combination of them)
-- [Hardware Limitations]({{< ref "../docs/attacks/timing-attacks/connection-pool.md" >}})
+> Does a query *?query=existent* return HTTP200 status code while *?query=non-existent* does not?"
 
-# About the Wiki
+The latter oracle could be formed from an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) XS-Leak and which could be abused by attackers to infer information about the user.
 
-This Wiki contains an introduction to XS-Leaks enriched with in-depth information. A reader is expected to be able to understand the topic, discover internals of some attacks and how to defend an application against them.
-This Wiki aggregates most of the XS-Leaks described and discovered in the wild but frequently new ones emerge. Please feel free to help this Wiki grow and be up to date by contributing to the [XS-Leaks Github Repository](https://github.com/xsleaks/wiki).
+## Example
+
+Websites are generally not allowed to access data on other websites. For example, *evil.com* is forbidden from explicitly reading a response from *bank.com*, but *evil.com* can attempt to load a script from *bank.com* since that was originally seen as harmless [^harmless]. However, *evil.com* can also determine whether or not the script successfully loaded.
+
+{{< hint info >}}
+
+Suppose that *bank.com* has an API endpoint that returns data about a user's receipt for a given query.
+
+1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script.
+2. If the user has recently bought groceries, it will load successfully (because of HTTP200 status code).
+3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of HTTP404 status code) that *evil.com* can watch for.
+4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history
+{{< /hint >}}
+
+In the above example, two websites on two different origins (*evil.com* and *bank.com*) were interacting through an API that browsers allow websites to use. None of this exploited a bug in the browser or a bug in *bank.com*. But nonetheless, it allowed *evil.com* to leak some small amount of information about the user on *bank.com*.  
+
+
+
+Browsers provide tons of different APIs that while well-intentioned, can end up leaking small amounts of information in an unintended way.
+
+## Root Cause of XS-Leaks
+
+The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes, applications are vulnerable to some cross-site information leaks without having explicitly done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of the techniques. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often must be combined to achieve the desired outcome.
+
+We can distinguish different sources of XS-Leaks, such as:
+
+-   Browser APIs 
+
+    -   For example: Frame Counting and Timing Attacks
+
+-   Browser Implementation Details and Bugs
+
+    -   For example: Connection Pooling and typeMustMatch
+
+-   Hardware Bugs
+
+    -   For example: Speculative Execution Attacks
+
+## A little bit of history
+
+XS-Leaks have always been part of the web platform but have only gained attention in recent years [^old-wiki] as websites became more secure against more traditional classes of vulnerabilities. In 2015 Gelernter and Herzberg published Cross-Site Search Attacks [^xs-search-first] which covered their work on exploiting timing attacks to implement XS-Search attacks against Google and Microsoft. From there, more XS-Leak techniques were discovered and tested over time. Recently, browsers have been working on developing a variety of new standards that will make it easier to defend applications against XS-Leaks.
+
+## About the wiki
+
+
+This wiki is meant to both introduce readers to XS-Leaks and serve as a reference guide to experienced researchers exploiting XS-Leaks. While this wiki contains information on many different techniques, new techniques are always emerging. Improvements, whether to add new techniques or improve existing pages, are always appreciated!
+
+## References
+[^side-channel]: Side Channel Vulnerabilities on the Web - Detection and Prevention, [link](https://owasp.org/www-pdf-archive/Side_Channel_Vulnerabilities.pdf)
+[^csrf]: Cross Site Request Forgery (CSRF), [link](https://owasp.org/www-community/attacks/csrf)
+[^STTF]: One of the examples for a feature with an accepted risk is [Scroll to Text Fragment]({{< ref "scroll-to-text-fragment.md" >}})
+[^harmless]: Websites being able to interact and include resources from each other is a key part of how the web works. For example, many websites allow users to post content that includes images embedded from elsewhere on the web. Fundamentally, this is an intended behavior of the web. But, over time the downsides of this sort of interaction have become better understood.
+[^hard-to-fix]: It is challenging to fix the root cause of XS-Leaks because in many cases doing so would break existing websites.
+[^old-wiki]: Browser Side Channels, [link](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels)
+[^xs-search-first]: Cross-Site Search Attacks, [link](https://446h.cybersec.fun/xssearch.pdf)

--- a/content/_index.md
+++ b/content/_index.md
@@ -38,7 +38,7 @@ Suppose that *bank.com* has an API endpoint that returns data about a user's rec
 4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history.
 {{< /hint >}}
 
-In the above example, two websites on two different origins (*evil.com* and *bank.com*) were interacting through an API that browsers allow websites to use. None of this exploited a bug in the browser or a bug in *bank.com*. But nonetheless, it allowed *evil.com* to leak some small amount of information about the user on *bank.com*.  
+In the above example, two websites on two different origins (*evil.com* and *bank.com*) were interacting through an API that browsers allow websites to use. None of this exploited a bug in the browser or a bug in *bank.com*. But nonetheless, it allowed *evil.com* to gain some small amount of information about the user on *bank.com*.  
 
 
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,6 +24,9 @@ In a vulnerable application, the above might be equivalent to:
 
 The latter oracle could be formed from an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) XS-Leak and which could be abused by attackers to infer information about the user.
 
+
+Browsers provide tons of different APIs that while well-intentioned, can end up leaking small amounts of information in an unintended way.
+
 ## Example
 
 Websites are generally not allowed to access data on other websites. For example, *evil.com* is forbidden from explicitly reading a response from *bank.com*, but *evil.com* can attempt to load a script from *bank.com* since that was originally seen as harmless [^harmless]. However, *evil.com* can also determine whether or not the script successfully loaded.
@@ -41,8 +44,6 @@ Suppose that *bank.com* has an API endpoint that returns data about a user's rec
 In the above example, two websites on two different origins (*evil.com* and *bank.com*) were interacting through an API that browsers allow websites to use. None of this exploited a bug in the browser or a bug in *bank.com*. But nonetheless, it allowed *evil.com* to gain some small amount of information about the user on *bank.com*.  
 
 
-
-Browsers provide tons of different APIs that while well-intentioned, can end up leaking small amounts of information in an unintended way.
 
 ## Root Cause of XS-Leaks
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -35,7 +35,7 @@ Websites are generally not allowed to access data on other websites. For example
 
 Suppose that *bank.com* has an API endpoint that returns data about a user's receipt for a given query.
 
-1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script, since by default , the browser will attach cookies with the request.
+1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script, since by default, the browser will attach cookies with the request.
 2. If the user has recently bought groceries, it will load successfully (because of the HTTP200 status code).
 3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can listen for.
 4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history.

--- a/content/_index.md
+++ b/content/_index.md
@@ -35,7 +35,7 @@ Suppose that *bank.com* has an API endpoint that returns data about a user's rec
 1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script.
 2. If the user has recently bought groceries, it will load successfully (because of the HTTP200 status code).
 3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can watch for.
-4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history
+4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history.
 {{< /hint >}}
 
 In the above example, two websites on two different origins (*evil.com* and *bank.com*) were interacting through an API that browsers allow websites to use. None of this exploited a bug in the browser or a bug in *bank.com*. But nonetheless, it allowed *evil.com* to leak some small amount of information about the user on *bank.com*.  

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,12 +7,12 @@ bookToc: false
 # XS-Leaks Wiki
 ## Overview
 
-Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF, XSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about them. This is done by utilising a variety of features built into browsers which are often maintained to preserve backwards compatibility. Though, sometimes new features are added to the browser despite an accepted risk of cross-site leaks [^STTF].
+Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about them. This is done by exploiting a variety of features built into browsers which might be maintained to preserve backwards compatibility. Though, sometimes new features are added to browsers regardless the introduction of potential cross-site leaks [^STTF] as the benefits are considered to overweight the downsides.
 
 
 ## The principle of an XS-Leak
 
-Websites interacting with each other is core to the behavior of the web. Browsers provide a wide variety of interfaces for such interaction between different web applications. These interfaces have different security measures built on top to try to constrain websites behavior (e.g. the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)). XS-Leaks take advantage of small pieces of information that can leak during these interactions in order to infer sensitive information about users. 
+Websites interacting with each other is core to the behavior of the web. Browsers provide a wide variety of interfaces for such interaction between different web applications. These interfaces have different security measures built on top to try to constrain websites behavior (e.g. the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)). XS-Leaks take advantage of small pieces of information that can leak during these interactions in order to infer sensitive information about users such as their data on other websites, operating systems they use or internal networks they are connected to. 
 
 These pieces of information usually have a binary form and are called oracles. These oracles usually answer with *YES* and *NO* to cleverly prepared questions. For example, such an oracle could be asked:
 
@@ -25,7 +25,7 @@ In a vulnerable application, the above might be equivalent to:
 The latter oracle could be formed from an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) XS-Leak and which could be abused by attackers to infer information about the user.
 
 
-Browsers provide tons of different APIs that while well-intentioned, can end up leaking small amounts of information in an unintended way.
+Browsers provide a wide range of different APIs that, while well-intended, can end up leaking small amounts of cross-origin information.
 
 ## Example
 
@@ -35,9 +35,9 @@ Websites are generally not allowed to access data on other websites. For example
 
 Suppose that *bank.com* has an API endpoint that returns data about a user's receipt for a given query.
 
-1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script.
+1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script, since by default , the browser will attach cookies with the request.
 2. If the user has recently bought groceries, it will load successfully (because of the HTTP200 status code).
-3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can watch for.
+3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can listen for.
 4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history.
 {{< /hint >}}
 
@@ -47,7 +47,7 @@ In the above example, two websites on two different origins (*evil.com* and *ban
 
 ## Root Cause of XS-Leaks
 
-The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes, applications are vulnerable to some cross-site information leaks without having explicitly done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of the techniques. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often must be combined to achieve the desired outcome.
+The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes applications are vulnerable to some cross-site information leaks without having done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of the issues. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener-Policy]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often times must be combined to achieve the desired outcome.
 
 We can distinguish different sources of XS-Leaks, such as:
 
@@ -62,12 +62,11 @@ We can distinguish different sources of XS-Leaks, such as:
 
 ## A little bit of history
 
-XS-Leaks have always been part of the web platform but have only gained attention in recent years [^old-wiki] as websites became more secure against more traditional classes of vulnerabilities. In 2015 Gelernter and Herzberg published Cross-Site Search Attacks [^xs-search-first] which covered their work on exploiting timing attacks to implement XS-Search attacks against Google and Microsoft. From there, more XS-Leak techniques were discovered and tested over time. Recently, browsers have been working on developing a variety of new standards that will make it easier to defend applications against XS-Leaks.
+XS-Leaks have always been part of the web platform but have only gained attention in recent years [^old-wiki] as websites became more secure against more traditional classes of vulnerabilities. In 2015 Gelernter and Herzberg published "Cross-Site Search Attacks" [^xs-search-first] which covered their work on exploiting timing attacks to implement XS-Search attacks against Google and Microsoft. From there, more XS-Leak techniques were discovered and tested over time. Recently, browsers have been working on developing a variety of new standards that will make it easier to defend applications against XS-Leaks.
 
 ## About the wiki
 
-
-This wiki is meant to both introduce readers to XS-Leaks and serve as a reference guide to experienced researchers exploiting XS-Leaks. While this wiki contains information on many different techniques, new techniques are always emerging. Improvements, whether to add new techniques or improve existing pages, are always appreciated!
+This wiki is meant to both introduce readers to XS-Leaks and serve as a reference guide to experienced researchers exploiting XS-Leaks. While this wiki contains information on many different techniques, new techniques are always emerging. Improvements, whether to add new techniques or expand existing pages, are always appreciated!
 
 ## References
 [^side-channel]: Side Channel Vulnerabilities on the Web - Detection and Prevention, [link](https://owasp.org/www-pdf-archive/Side_Channel_Vulnerabilities.pdf)

--- a/content/_index.md
+++ b/content/_index.md
@@ -34,7 +34,7 @@ Suppose that *bank.com* has an API endpoint that returns data about a user's rec
 
 1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script.
 2. If the user has recently bought groceries, it will load successfully (because of HTTP200 status code).
-3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of HTTP404 status code) that *evil.com* can watch for.
+3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can watch for.
 4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history
 {{< /hint >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -33,7 +33,7 @@ Websites are generally not allowed to access data on other websites. For example
 Suppose that *bank.com* has an API endpoint that returns data about a user's receipt for a given query.
 
 1. The page *evil.com* could attempt to load the URL *bank.com/my_receipt?q=groceries* as a script.
-2. If the user has recently bought groceries, it will load successfully (because of HTTP200 status code).
+2. If the user has recently bought groceries, it will load successfully (because of the HTTP200 status code).
 3. But if they haven't, it will trigger an [Error Event]({{< ref "./docs/attacks/error-events.md" >}}) (because of the HTTP404 status code) that *evil.com* can watch for.
 4. By repeating this with different queries, the attacker could infer a significant amount of information about the user's transaction history
 {{< /hint >}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,22 +47,17 @@ In the above example, two websites on two different origins (*evil.com* and *ban
 
 ## Root Cause of XS-Leaks
 
-The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes applications are vulnerable to some cross-site information leaks without having done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of the issues. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener-Policy]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often times must be combined to achieve the desired outcome.
+The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes applications are vulnerable to some cross-site information leaks without having done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of these issues. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener-Policy]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often times must be combined to achieve the desired outcome.
 
 We can distinguish different sources of XS-Leaks, such as:
 
--   Browser APIs 
-    -   For example: [Frame Counting]({{< ref "frame-counting.md" >}}) and [Timing Attacks]({{< ref "timing-attacks.md" >}})
-
--   Browser Implementation Details and Bugs
-    -   For example: [Connection Pooling]({{< ref "./docs/attacks/timing-attacks/connection-pool.md" >}}) and [typeMustMatch]({{< ref "./docs/attacks/historical/content-type.md#typemustmatch" >}})
-
--   Hardware Bugs
-    -   For example: Speculative Execution Attacks [^spectre]
+1. Browser APIs (e.g. [Frame Counting]({{< ref "frame-counting.md" >}}) and [Timing Attacks]({{< ref "timing-attacks.md" >}}))
+2. Browser Implementation Details and Bugs (e.g. [Connection Pooling]({{< ref "./docs/attacks/timing-attacks/connection-pool.md" >}}) and [typeMustMatch]({{< ref "./docs/attacks/historical/content-type.md#typemustmatch" >}}))
+3. Hardware Bugs (e.g. Speculative Execution Attacks [^spectre])
 
 ## A little bit of history
 
-XS-Leaks have always been part of the web platform but have only gained attention in recent years [^old-wiki] as websites became more secure against more traditional classes of vulnerabilities. In 2015 Gelernter and Herzberg published "Cross-Site Search Attacks" [^xs-search-first] which covered their work on exploiting timing attacks to implement XS-Search attacks against Google and Microsoft. From there, more XS-Leak techniques were discovered and tested over time. Recently, browsers have been working on developing a variety of new standards that will make it easier to defend applications against XS-Leaks.
+XS-Leaks have always been part of the web platform but have gained attention in recent years [^old-wiki] as new techniques were found to increase their impact. [Timing attacks]({{< ref "network-timing.md" >}}) against the web have been discussed since at least [2000](https://dl.acm.org/doi/10.1145/352600.352606). In 2015 Gelernter and Herzberg published "Cross-Site Search Attacks" [^xs-search-first] which covered their work on exploiting timing attacks to implement high impact XS-Search attacks against Google and Microsoft. From there, more XS-Leak techniques were discovered and tested over time. Recently, browsers have been working on developing a variety of new standards that will make it easier to defend applications against XS-Leaks.
 
 ## About the wiki
 
@@ -78,4 +73,3 @@ This wiki is meant to both introduce readers to XS-Leaks and serve as a referenc
 [^old-wiki]: Browser Side Channels, [link](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels)
 [^xs-search-first]: Cross-Site Search Attacks, [link](https://446h.cybersec.fun/xssearch.pdf)
 [^spectre]: Meltdown and Spectre, [link](https://spectreattack.com/)
-

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from
 
 ## The principle of an XS-Leak
 
-Websites interacting with each other is core to the behavior of the web. Browsers provide a wide variety of interfaces for such interaction between different web applications. These interfaces have a wide variety of security measures built on top to try to constrain websites behavior (e.g. the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)). XS-Leaks take advantage of small pieces of information that can leak during these interactions in order to infer sensitive information about users. 
+Websites interacting with each other is core to the behavior of the web. Browsers provide a wide variety of interfaces for such interaction between different web applications. These interfaces have different security measures built on top to try to constrain websites behavior (e.g. the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)). XS-Leaks take advantage of small pieces of information that can leak during these interactions in order to infer sensitive information about users. 
 
 These pieces of information usually have a binary form and are called oracles. These oracles usually answer with *YES* and *NO* to cleverly prepared questions. For example, such an oracle could be asked:
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ bookToc: false
 # XS-Leaks Wiki
 ## Overview
 
-Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about them. This is done by exploiting a variety of features built into browsers which might be maintained to preserve backwards compatibility. Though, sometimes new features are added to browsers regardless the introduction of potential cross-site leaks [^STTF] as the benefits are considered to overweight the downsides.
+Cross-Site Leaks (XS-Leaks, XSLeaks) are a class of vulnerabilities derived from browser side-channel techniques [^side-channel]. These are similar to Cross-Site Request Forgery [^csrf] (CSRF) techniques but instead of allowing other websites to take actions on behalf of a user, they can be used to infer information about them. This is done by exploiting a variety of features built into browsers [^browser-features].
 
 
 ## The principle of an XS-Leak
@@ -71,9 +71,11 @@ This wiki is meant to both introduce readers to XS-Leaks and serve as a referenc
 ## References
 [^side-channel]: Side Channel Vulnerabilities on the Web - Detection and Prevention, [link](https://owasp.org/www-pdf-archive/Side_Channel_Vulnerabilities.pdf)
 [^csrf]: Cross Site Request Forgery (CSRF), [link](https://owasp.org/www-community/attacks/csrf)
+[^browser-features]: These features might be maintained to preserve backwards compatibility, though, sometimes new features are added to browsers regardless of the introduction of potential cross-site leaks [^STTF] as the benefits are considered to outweigh the downsides.
 [^STTF]: One of the examples for a feature with an accepted risk is [Scroll to Text Fragment]({{< ref "scroll-to-text-fragment.md" >}})
 [^harmless]: Websites being able to interact and include resources from each other is a key part of how the web works. For example, many websites allow users to post content that includes images embedded from elsewhere on the web. Fundamentally, this is an intended behavior of the web. But, over time the downsides of this sort of interaction have become better understood.
 [^hard-to-fix]: It is challenging to fix the root cause of XS-Leaks because in many cases doing so would break existing websites.
 [^old-wiki]: Browser Side Channels, [link](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels)
 [^xs-search-first]: Cross-Site Search Attacks, [link](https://446h.cybersec.fun/xssearch.pdf)
 [^spectre]: Meltdown and Spectre, [link](https://spectreattack.com/)
+

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,7 +47,7 @@ In the above example, two websites on two different origins (*evil.com* and *ban
 
 ## Root Cause of XS-Leaks
 
-The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes applications are vulnerable to some cross-site information leaks without having done anything wrong. Because it is hard [^hard-to-fix] to universally fix the root cause of XS-Leaks at the browser level, browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of these issues. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener-Policy]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often times must be combined to achieve the desired outcome.
+The root cause of most XS-Leaks is inherent to the design of the web. Oftentimes applications are vulnerable to some cross-site information leaks without having done anything wrong. It is challenging to fix the root cause of XS-Leaks at the browser level because in many cases doing so would break existing websites so browsers are implementing various [Defense Mechanisms]({{< ref "defenses" >}}) that offer applications ways of mitigating some of these issues. Many of these mitigations are used via websites opting into a more restrictive security model, usually through certain HTTP headers (e.g. *[Cross-Origin-Opener-Policy]({{< ref "./docs/defenses/opt-in/coop.md">}}): same-origin*), which often times must be combined to achieve the desired outcome.
 
 We can distinguish different sources of XS-Leaks, such as:
 
@@ -69,7 +69,6 @@ This wiki is meant to both introduce readers to XS-Leaks and serve as a referenc
 [^browser-features]: These features might be maintained to preserve backwards compatibility, though, sometimes new features are added to browsers regardless of the introduction of potential cross-site leaks [^STTF] as the benefits are considered to outweigh the downsides.
 [^STTF]: One of the examples for a feature with an accepted risk is [Scroll to Text Fragment]({{< ref "scroll-to-text-fragment.md" >}})
 [^harmless]: Websites being able to interact and include resources from each other is a key part of how the web works. For example, many websites allow users to post content that includes images embedded from elsewhere on the web. Fundamentally, this is an intended behavior of the web. But, over time the downsides of this sort of interaction have become better understood.
-[^hard-to-fix]: It is challenging to fix the root cause of XS-Leaks because in many cases doing so would break existing websites.
 [^old-wiki]: Browser Side Channels, [link](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels)
 [^xs-search-first]: Cross-Site Search Attacks, [link](https://446h.cybersec.fun/xssearch.pdf)
 [^spectre]: Meltdown and Spectre, [link](https://spectreattack.com/)


### PR DESCRIPTION
Together with @ddworken we rewrote the introduction section a little bit. 

@manuelvsousa for the Hugo syntax & the contents
@empijei for the overall look and other suggestions

Visually it looks like this:
![image](https://user-images.githubusercontent.com/11320896/96165192-9b10c300-0f1c-11eb-9d47-3e2bc4bb1662.png)
