### PR TITLE
Remove the last of the bold

### DIFF
--- a/content/docs/attacks/postmessage-broadcasts.md
+++ b/content/docs/attacks/postmessage-broadcasts.md
@@ -15,16 +15,17 @@ menu = "main"
 weight = 3
 +++
 
-Applications often use [postMessage broadcasts](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to provide information to any interested origin. Apart from the obvious security issues (providing sensitive information to any origin), other problems might occur if a legitimate postMessage broadcast is not properly implemented [^1].
+Applications often use [postMessage broadcasts](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to share information with other origins. `postMessage` can lead to two kinds of XS-Leaks:
 
-If a broadcast happens based on user information, attackers might be able to leak information if they can distinguish two scenarios. There are multiple ways applications can be inconsistent with broadcast:
+* Sensitive messages shared with untrusted origins
+    * The `postMessage` API supports a `targetOrigin` parameter that can be used to restrict which origins can receive the message. If the message contains any sensitive data, it is important to use this parameter.  
 
-- An application sends different broadcasted messages.
-- An application sends a broadcast or no broadcast.
+* Leaking information based on different content or on the presence of a broadcast
+    * Similar to other XS-Leak techniques, this could be used to form an oracle. For example, if an application sent out a postMessage broadcast saying "Page Loaded" only if a user existed with a given username, this could be used to leak information. 
 
 ## Defense
 
-There is no clear solution to mitigate this XS-Leak as it depends deeply on the purpose of doing a postMessage broadcast. Applications should limit postMessage communications to a group of known origins and, when this is not possible, they should have the same behavior even when in different states to prevent attackers from inferring any differences.
+There is no clear solution to mitigate this XS-Leak as it depends deeply on the purpose of doing a postMessage broadcast. Applications should limit postMessage communications to a group of known origins and when this is not possible they should have the same behavior even when in different states to prevent attackers from inferring any differences.
 
 ## References
 

--- a/content/docs/attacks/timing-attacks/connection-pool.md
+++ b/content/docs/attacks/timing-attacks/connection-pool.md
@@ -20,7 +20,7 @@ To exploit the existence of this limit attackers can:
 1. Check what is the limit of the browser, for example 256 global sockets.
 2. Block {{< katex>}}255{{< /katex >}} sockets for a long period of time by performing {{< katex>}}255{{< /katex >}} requests to different hosts that simply hang the connection
 3. Use the {{< katex>}}256^{th}{{< /katex >}} socket by performing a request to the target page.
-4. Preform a {{< katex>}}257^{th}{{< /katex >}} request to another host. Since all the sockets are being used (in steps 2 and 3), this request must wait until the pool gets an available socket. This waiting period will give the attacker the network timing of the {{< katex>}}256^{th}{{< /katex >}} socket, which belongs to the target page. This occurs because the {{< katex>}}255{{< /katex >}} sockets in step 2. are still blocked, so if the pool got an available socket it was caused by the release of the socket in step 3. **The time to release the {{< katex>}}256^{th}{{< /katex >}} socket is directly connected with the time taken to complete the request**.
+4. Preform a {{< katex>}}257^{th}{{< /katex >}} request to another host. Since all the sockets are being used (in steps 2 and 3), this request must wait until the pool gets an available socket. This waiting period will give the attacker the network timing of the {{< katex>}}256^{th}{{< /katex >}} socket, which belongs to the target page. This occurs because the {{< katex>}}255{{< /katex >}} sockets in step 2. are still blocked, so if the pool got an available socket it was caused by the release of the socket in step 3. The time to release the {{< katex>}}256^{th}{{< /katex >}} socket is directly connected with the time taken to complete the request.
 
 ## Defense
 

--- a/content/docs/defenses/opt-in/corp.md
+++ b/content/docs/defenses/opt-in/corp.md
@@ -8,7 +8,7 @@ category = [
 menu = "main"
 +++
 
-Cross-Origin Resource Policy (CORP) is a web platform security feature that allows websites to prevent certain resources from being loaded by other origins. This protection complements CORB since it is an opt-in defense whereas CORB blocks some cross-origin reads by default. It is designed to protect against both speculative execution attacks and XS-Leaks by allowing developers to ensure that sensitive resources cannot end up in attacker controlled processes. Unlike CORB, this protection is enforced in the browser only if an application **opts in to the protection**. Applications can define which groups of origins (same-site, same-origin, cross-site) are allowed to read their resources.
+Cross-Origin Resource Policy (CORP) is a web platform security feature that allows websites to prevent certain resources from being loaded by other origins. This protection complements CORB since it is an opt-in defense whereas CORB blocks some cross-origin reads by default. It is designed to protect against both speculative execution attacks and XS-Leaks by allowing developers to ensure that sensitive resources cannot end up in attacker controlled processes. Unlike CORB, this protection is enforced in the browser only if an application opts in to the protection. Applications can define which groups of origins (same-site, same-origin, cross-site) are allowed to read their resources.
 
 If an application sets a certain resource CORP Header as same-site or same-origin, an attacker origin is incapable of reading that resource. This is a very strong and highly encouraged protection. 
 


### PR DESCRIPTION
I went through the defense section again looking for places that I thought bold might help and decided that I don't think it is necessary anywhere given the current state of the wiki. I think generally, wherever one uses bold it can generally be done better with formatting such as a new or a new line. So I just ended up removing two bits of bold I missed last time.