### PR TITLE
Clarify the postMessage xs leak doc

### DIFF
--- a/content/docs/attacks/postmessage-broadcasts.md
+++ b/content/docs/attacks/postmessage-broadcasts.md
@@ -15,16 +15,17 @@ menu = "main"
 weight = 3
 +++
 
-Applications often use [postMessage broadcasts](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to provide information to any interested origin. Apart from the obvious security issues (providing sensitive information to any origin), other problems might occur if a legitimate postMessage broadcast is not properly implemented [^1].
+Applications often use [postMessage broadcasts](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to share information with other origins. `postMessage` can lead to two kinds of XS-Leaks:
 
-If a broadcast happens based on user information, attackers might be able to leak information if they can distinguish two scenarios. There are multiple ways applications can be inconsistent with broadcast:
+* Sensitive messages shared with untrusted origins
+    * The `postMessage` API supports a `targetOrigin` parameter that can be used to restrict which origins can receive the message. If the message contains any sensitive data, it is important to use this parameter.  
 
-- An application sends different broadcasted messages.
-- An application sends a broadcast or no broadcast.
+* Leaking information based on different content or on the presence of a broadcast
+    * Similar to other XS-Leak techniques, this could be used to form an oracle. For example, if an application sent out a postMessage broadcast saying "Page Loaded" only if a user existed with a given username, this could be used to leak information. 
 
 ## Defense
 
-There is no clear solution to mitigate this XS-Leak as it depends deeply on the purpose of doing a postMessage broadcast. Applications should limit postMessage communications to a group of known origins and, when this is not possible, they should have the same behavior even when in different states to prevent attackers from inferring any differences.
+There is no clear solution to mitigate this XS-Leak as it depends deeply on the purpose of doing a postMessage broadcast. Applications should limit postMessage communications to a group of known origins and when this is not possible they should have the same behavior even when in different states to prevent attackers from inferring any differences.
 
 ## References
 


### PR DESCRIPTION
Tried to clarify the two cases where `postMessage` can lead to leaking information cross origin