### PR TITLE
change monokai to dracula

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,3 +27,7 @@ theme = "book"
   abuse = "Abuse"
   category = "Category"
   defense = "Defenses"
+
+[markup]
+  [markup.highlight]
+    style = "dracula"


### PR DESCRIPTION
Changed the Monokai highlight theme to Dracula. In the future we could also consider adding a light theme to the wiki, but default ones do not look too good IMO.

https://xyproto.github.io/splash/docs/all.html

![image](https://user-images.githubusercontent.com/11320896/98689340-1cb50e80-236c-11eb-8972-76489893af25.png)
