### PR TITLE
Split Contributions to a separate article

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -69,7 +69,7 @@ Recently, browsers have implemented a variety of new [defense mechanisms]({{< re
 
 This wiki is meant to both introduce readers to XS-Leaks and serve as a reference guide for experienced researchers exploiting XS-Leaks. While this wiki contains information on many different techniques, new techniques are always emerging. Improvements, whether they add new techniques or expand existing pages, are always appreciated!
 
-More information about contributions can be found in the [Contributions]({{< ref "contributions.md" >}}) article where also all the contributors are acknnowledged.
+Find out how you can contribute to this wiki and view the list of contributors in the [Contributions]({{< ref "contributions.md" >}}) article.
 
 ## References
 [^side-channel]: Side Channel Vulnerabilities on the Web - Detection and Prevention, [link](https://owasp.org/www-pdf-archive/Side_Channel_Vulnerabilities.pdf)

--- a/content/_index.md
+++ b/content/_index.md
@@ -69,27 +69,7 @@ Recently, browsers have implemented a variety of new [defense mechanisms]({{< re
 
 This wiki is meant to both introduce readers to XS-Leaks and serve as a reference guide for experienced researchers exploiting XS-Leaks. While this wiki contains information on many different techniques, new techniques are always emerging. Improvements, whether they add new techniques or expand existing pages, are always appreciated!
 
-### Contributors
-
-The following users [contributed](https://github.com/xsleaks/wiki/graphs/contributors) to the XS-Leaks wiki:
-
-* [Manuel Sousa](https://github.com/manuelvsousa) (creator of this wiki)
-* [terjanq](https://github.com/terjanq)
-* [Roberto Clapis](https://github.com/empijei)
-* [David Dworken](https://github.com/ddworken)
-* [NDevTK](https://github.com/NDevTK)
-
-In addition, we would also like to acknowledge the users who [contributed](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels/_history) to the predecessor of the current XS-Leaks wiki:
-
-* [Eduardo' Vela" \<Nava> (sirdarckcat)](https://github.com/sirdarckcat)
-* [Ron Masas](https://github.com/masasron)
-* [Luan Herrera](https://github.com/lbherrera)
-* [Sigurd](https://github.com/DonSheddow)
-* [larson reever](https://github.com/larsonreever)
-* [Frederik Braun](https://github.com/mozfreddyb)
-* [Masato Kinugawa](https://github.com/masatokinugawa)
-* [sroettger](https://github.com/sroettger)
-
+More information about contributions can be found in the [Contributions]({{< ref "contributions.md" >}}) article where also all the contributors are acknnowledged.
 
 ## References
 [^side-channel]: Side Channel Vulnerabilities on the Web - Detection and Prevention, [link](https://owasp.org/www-pdf-archive/Side_Channel_Vulnerabilities.pdf)

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -79,9 +79,9 @@ The original hint style can be used by adding a third parameter, `noTitle`, to t
 
 {{< /hint >}}
 
-## Acknowledgement
+## Acknowledgements
 
-We would like to acknowledge the following users who [contributed](https://github.com/xsleaks/wiki/graphs/contributors) to this XS-Leaks wiki:
+We would like to thank the following users who [contributed](https://github.com/xsleaks/wiki/graphs/contributors) to this XS-Leaks wiki:
 
 [Manuel Sousa](https://github.com/manuelvsousa), [terjanq](https://github.com/terjanq),
 [Roberto Clapis](https://github.com/empijei), [David Dworken](https://github.com/ddworken),

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -1,0 +1,107 @@
+---
+weight: 1000
+bookFlatSection: true
+title: "Contributions"
+---
+
+# Contributions
+
+## Guidelines
+
+The contents of the articles lie in the `/content` directory in the [wiki repository](https://github.com/xsleaks/wiki/tree/master/content).
+
+You can make changes to the articles in various ways:
+
+### Pull requests
+
+In order to submit a Pull Request:
+1. Fork the repository.
+2. Make changes there and put them into a pull request.
+3. Submit a pull request of the branch to master in the main folder.
+
+If you are not sure about the folder structure, you can look up how other articles were written.
+
+### Direct edits
+Under every article, there is `Edit this article` anchor which will redirect you directly to the GitHub editor.
+
+### Github issues
+If none of the above options work for you, it will be appreciated if you created a [new issue](https://github.com/xsleaks/wiki/issues/new) in the main wiki repository where you can explain the improvement, issue, or any other comment you have regarding the current version of the wiki.
+
+## Local deployment
+The wiki is built with the [Hugo framework](https://gohugo.io/getting-started/installing/).
+
+You can run run the local environment via the following steps:
+
+1. Install the [Hugo Framework](https://gohugo.io/getting-started/installing/) **extended** version > 0.68.
+2. Clone this repo.
+3. Run `hugo server --minify` in root directory.
+4. Open your browser and go to http://localhost:1313 (or as indicated by hugo output).
+
+## Wiki Theme
+
+We use the [Hugo Book Theme](https://themes.gohugo.io/hugo-book/) with custom modifications.
+
+### Custom hint shortcode.
+We modified the default [Hints](https://themes.gohugo.io/theme/hugo-book/docs/shortcodes/hints/) from the theme and the modified boxes are listed below:
+
+{{< hint info >}}
+```
+{{</* hint info */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+{{< hint note >}}
+```
+{{</* hint note */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+{{< hint example >}}
+```
+{{</* hint example */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+{{< hint tip >}}
+```
+{{</* hint tip */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+{{< hint important >}}
+```
+{{</* hint important */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+{{< hint warning >}}
+```
+{{</* hint warning */>}} TEXT {{</* /hint */>}}
+```
+{{< /hint >}}
+
+### Original style
+The original style can be used by adding a third parameter `noTitle` to the shortcode, e.g.
+
+{{< hint example noTitle>}}
+
+`{{</* hint example noTitle */>}}`
+
+{{< /hint >}}
+
+## Acknowledgement
+
+We would like to acknowledge the following users who [contributed](https://github.com/xsleaks/wiki/graphs/contributors) to this XS-Leaks wiki:
+
+[Manuel Sousa](https://github.com/manuelvsousa), [terjanq](https://github.com/terjanq),
+[Roberto Clapis](https://github.com/empijei), [David Dworken](https://github.com/ddworken),
+[NDevTK](https://github.com/NDevTK)
+
+In addition, we would also like to acknowledge the users who [contributed](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels/_history) to the predecessor of the current XS-Leaks wiki:
+
+[Eduardo' Vela" \<Nava> (sirdarckcat)](https://github.com/sirdarckcat), [Ron Masas](https://github.com/masasron),
+[Luan Herrera](https://github.com/lbherrera), [Sigurd](https://github.com/DonSheddow),
+[larson reever](https://github.com/larsonreever), [Frederik Braun](https://github.com/mozfreddyb)
+[Masato Kinugawa](https://github.com/masatokinugawa), [sroettger](https://github.com/sroettger)
+
+And all other amazing researchers that participate in sharing and exploring depths of XS-Leaks!

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -6,43 +6,45 @@ title: "Contributions"
 
 # Contributions
 
-## Guidelines
+This page explains how you can contribute to the XS-Leaks wiki and acknowledges the users who have contributed content.
 
-The contents of the articles lie in the `/content` directory in the [wiki repository](https://github.com/xsleaks/wiki/tree/master/content).
+## Contribution guidelines
 
-You can make changes to the articles in various ways:
+The article source files reside in the `/content` directory in the [wiki repository](https://github.com/xsleaks/wiki/tree/master/content).
+
+You can make changes to articles in various ways:
 
 ### Pull requests
 
-In order to submit a Pull Request:
+In order to submit a pull request:
 1. Fork the repository.
-2. Make changes there and put them into a pull request.
-3. Submit a pull request of the branch to master in the main folder.
+2. Make changes there and place them into a pull request.
+3. Submit the pull request of the branch to master in the main folder.
 
 If you are not sure about the folder structure, you can look up how other articles were written.
 
 ### Direct edits
-Under every article, there is `Edit this article` anchor which will redirect you directly to the GitHub editor.
+Under every article, there is an `Edit this article` anchor which redirects you straight to the GitHub editor.
 
 ### Github issues
-If none of the above options work for you, it will be appreciated if you created a [new issue](https://github.com/xsleaks/wiki/issues/new) in the main wiki repository where you can explain the improvement, issue, or any other comment you have regarding the current version of the wiki.
+If neither of the above options work for you, we'd appreciate if you created a [new issue](https://github.com/xsleaks/wiki/issues/new) in the main wiki repository where you can explain the improvement, issue, or any other comment you have regarding the current version of the wiki.
 
 ## Local deployment
-The wiki is built with the [Hugo framework](https://gohugo.io/getting-started/installing/).
+The wiki is built using the [Hugo framework](https://gohugo.io/getting-started/installing/).
 
-You can run run the local environment via the following steps:
+You can run a local environment by following these steps:
 
-1. Install the [Hugo Framework](https://gohugo.io/getting-started/installing/) **extended** version > 0.68.
+1. Install the [Hugo Framework](https://gohugo.io/getting-started/installing/), **extended** version > 0.68.
 2. Clone this repo.
-3. Run `hugo server --minify` in root directory.
-4. Open your browser and go to http://localhost:1313 (or as indicated by hugo output).
+3. Run `hugo server --minify` in the root directory.
+4. Open your browser and go to http://localhost:1313 (or as indicated by the Hugo output).
 
-## Wiki Theme
+## Wiki theme
 
 We use the [Hugo Book Theme](https://themes.gohugo.io/hugo-book/) with custom modifications.
 
-### Custom hint shortcode.
-We modified the default [Hints](https://themes.gohugo.io/theme/hugo-book/docs/shortcodes/hints/) from the theme and the modified boxes are listed below:
+### Custom hint shortcode
+We modified the default [Hints](https://themes.gohugo.io/theme/hugo-book/docs/shortcodes/hints/) used by the theme; the modified boxes are listed below:
 
 {{< hint info >}}
 ```
@@ -81,7 +83,7 @@ We modified the default [Hints](https://themes.gohugo.io/theme/hugo-book/docs/sh
 {{< /hint >}}
 
 ### Original style
-The original style can be used by adding a third parameter `noTitle` to the shortcode, e.g.
+The original hint style can be used by adding a third parameter, `noTitle`, to the shortcode, e.g.:
 
 {{< hint example noTitle>}}
 
@@ -104,4 +106,4 @@ In addition, we would also like to acknowledge the users who [contributed](https
 [larson reever](https://github.com/larsonreever), [Frederik Braun](https://github.com/mozfreddyb)
 [Masato Kinugawa](https://github.com/masatokinugawa), [sroettger](https://github.com/sroettger)
 
-And all other amazing researchers that participate in sharing and exploring depths of XS-Leaks!
+And finally, our thanks go to all other amazing researchers that participate in sharing and exploring the depths of XS-Leaks!

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -47,39 +47,27 @@ We use the [Hugo Book Theme](https://themes.gohugo.io/hugo-book/) with custom mo
 We modified the default [Hints](https://themes.gohugo.io/theme/hugo-book/docs/shortcodes/hints/) used by the theme; the modified boxes are listed below:
 
 {{< hint info >}}
-```
-{{</* hint info */>}} TEXT {{</* /hint */>}}
-```
+This is an *Info* box for the `{{</* hint info */>}}` shortcode.
 {{< /hint >}}
 
 {{< hint note >}}
-```
-{{</* hint note */>}} TEXT {{</* /hint */>}}
-```
+This is a *Note* box for the `{{</* hint note */>}}` shortcode.
 {{< /hint >}}
 
 {{< hint example >}}
-```
-{{</* hint example */>}} TEXT {{</* /hint */>}}
-```
+This is an *Example* box for the `{{</* hint example */>}}` shortcode.
 {{< /hint >}}
 
 {{< hint tip >}}
-```
-{{</* hint tip */>}} TEXT {{</* /hint */>}}
-```
+This is a *Tip* box for the `{{</* hint tip */>}}` shortcode.
 {{< /hint >}}
 
 {{< hint important >}}
-```
-{{</* hint important */>}} TEXT {{</* /hint */>}}
-```
+This is an *Important* box for the `{{</* hint important */>}}` shortcode.
 {{< /hint >}}
 
 {{< hint warning >}}
-```
-{{</* hint warning */>}} TEXT {{</* /hint */>}}
-```
+This is a *Warning* box for the `{{</* hint warning */>}}` shortcode.
 {{< /hint >}}
 
 ### Original style


### PR DESCRIPTION
Per the issue https://github.com/xsleaks/wiki/issues/81 I drafted a separate contributions section. @goedi02 and @arturjanc 
 could you take look at this? I think this is an important change before we announce the wiki to the public.