### PR TITLE
Fix JS snippet on cache-probing.md

### DIFF
--- a/content/docs/attacks/cache-probing.md
+++ b/content/docs/attacks/cache-probing.md
@@ -67,16 +67,18 @@ If a resource hosted on `server.com` is requested from `target.com` then the ori
 // The function simply take a url and fetch it in CORS mode
 // if the fetch raises an error, it will be a CORS error due to the 
 // origin mismatch between attacker.com and victim's ip
-function isResourceCached(url) {
+function ifCached(url) {
     return fetch(url, {
         mode: "cors"
-    }).then(() => false, (e) => true);
+    })
+    .then((response) => false)
+    .catch((error) => true);
 }
 
 // This makes sense only if the attacker alredy knows that
 // server.com suffers from origin reflection CORS misconfiguration
 var resource_url = "server.com/reflected_origin_resource.html"
-verdict = await isResourceCached(resource_url)
+verdict = await ifCached(resource_url)
 console.log("Resource was cached: " + verdict)
 ```
 

--- a/content/docs/attacks/cache-probing.md
+++ b/content/docs/attacks/cache-probing.md
@@ -67,19 +67,16 @@ If a resource hosted on `server.com` is requested from `target.com` then the ori
 // The function simply take a url and fetch it in CORS mode
 // if the fetch raises an error, it will be a CORS error due to the 
 // origin mismatch between attacker.com and victim's ip
-function checkCachedResource(url) {
-    fetch(url, {
+function isResourceCached(url) {
+    return fetch(url, {
         mode: "cors"
-        }).catch((e) => {
-            return true
-        });
-    return false
+    }).then(() => false, (e) => true);
 }
 
 // This makes sense only if the attacker alredy knows that
 // server.com suffers from origin reflection CORS misconfiguration
 var resource_url = "server.com/reflected_origin_resource.html"
-verdict = checkCachedResource(resource_url)
+verdict = await isResourceCached(resource_url)
 console.log("Resource was cached: " + verdict)
 ```
 

--- a/content/docs/attacks/cache-probing.md
+++ b/content/docs/attacks/cache-probing.md
@@ -68,11 +68,13 @@ If a resource hosted on `server.com` is requested from `target.com` then the ori
 // If the fetch raises an error, it will be a CORS error due to the 
 // origin mismatch between attacker.com and victim's IP.
 function ifCached(url) {
+    // returns a promise that resolves to true on fetch error 
+    // and to false on success
     return fetch(url, {
         mode: "cors"
     })
-    .then((response) => false)
-    .catch((error) => true);
+    .then(() => false)
+    .catch(() => true);
 }
 
 // This makes sense only if the attacker already knows that

--- a/content/docs/attacks/cache-probing.md
+++ b/content/docs/attacks/cache-probing.md
@@ -78,7 +78,7 @@ function ifCached(url) {
 // This makes sense only if the attacker alredy knows that
 // server.com suffers from origin reflection CORS misconfiguration
 var resource_url = "server.com/reflected_origin_resource.html"
-verdict = await ifCached(resource_url)
+var verdict = await ifCached(resource_url)
 console.log("Resource was cached: " + verdict)
 ```
 

--- a/content/docs/attacks/cache-probing.md
+++ b/content/docs/attacks/cache-probing.md
@@ -64,9 +64,9 @@ If a resource hosted on `server.com` is requested from `target.com` then the ori
 - The resource is not in cache: the resource could be fetched and stored together with the `Access-Control-Allow-Origin: attacker.com` header.
 - The resource was already in cache: fetch attempt will try to fetch the resource from the cache but it will also generate a CORS error due to the ACAO header value mismatch with the requesting origin (`target.com` origin was expected but `attacker.com` was provided). Here below is provided an example code snippet epxloting this vulnerability to infer the cache status of the victim's browser. 
 ```javascript
-// The function simply take a url and fetch it in CORS mode
-// if the fetch raises an error, it will be a CORS error due to the 
-// origin mismatch between attacker.com and victim's ip
+// The function simply takes a url and fetches it in CORS mode.
+// If the fetch raises an error, it will be a CORS error due to the 
+// origin mismatch between attacker.com and victim's IP.
 function ifCached(url) {
     return fetch(url, {
         mode: "cors"
@@ -75,8 +75,8 @@ function ifCached(url) {
     .catch((error) => true);
 }
 
-// This makes sense only if the attacker alredy knows that
-// server.com suffers from origin reflection CORS misconfiguration
+// This makes sense only if the attacker already knows that
+// server.com suffers from origin reflection CORS misconfiguration.
 var resource_url = "server.com/reflected_origin_resource.html"
 var verdict = await ifCached(resource_url)
 console.log("Resource was cached: " + verdict)

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -86,7 +86,8 @@ We would like to thank the following users who [contributed](https://github.com/
 [Manuel Sousa](https://github.com/manuelvsousa), [terjanq](https://github.com/terjanq),
 [Roberto Clapis](https://github.com/empijei), [David Dworken](https://github.com/ddworken),
 [NDevTK](https://github.com/NDevTK), [1lastBr3ath](https://twitter.com/1lastBr3ath),
-[Brasco](https://github.com/Brasco/), [rick.titor](https://github.com/riccardomerlano)
+[Brasco](https://github.com/Brasco/), [rick.titor](https://github.com/riccardomerlano),
+[Chris Fredrickson](https://github.com/cfredric/)
 
 In addition, we would also like to acknowledge the users who [contributed](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels/_history) to the predecessor of the current XS-Leaks wiki:
 


### PR DESCRIPTION
This PR fixes a JS snippet that's a bit nonsensical. As written `checkCachedResource` function always returned `false`, instead of returning `true` if the `fetch` raised an error. (The return value in the closure in `.catch` is ignored, since the return value of the `fetch` is ignored.)

This PR also changes the name of the `checkCachedResource` to `isResourceCached`, which more clearly conveys the semantics of the function.