### PR TITLE
Update cross-site frame counting real world example section with a new patched bug on GitHub

### DIFF
--- a/content/docs/attacks/css-tricks.md
+++ b/content/docs/attacks/css-tricks.md
@@ -20,21 +20,24 @@ CSS can be used to trick a user into exposing information such as embedded pixel
 
 ## Retrieving user's history
 Using the CSS [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited) selector, it’s possible to apply a different style for URLs that have been visited.  
-Previously it was possible to use [`getComputedStyle()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) to detect this difference but now browsers prevent this by always returing values as if the link was visted and limiting what styles can be applyed using the selector. [^changes-1]   
-So, it may be needed to trick the user into clicking an area that the CSS has affected this can be done using [`mix-blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode). [^blend-mode]   
-There are also ways to do it without user interaction such as by abusing render timings this works because it takes time to paint links a different color. [^render-timings]  
+Previously it was possible to use [`getComputedStyle()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) to detect this difference, but now browsers prevent this by always returing values as if the link was visted and limiting what styles can be applyed using the selector. [^changes-1]   
+So, it may be needed to trick the user into clicking an area that the CSS has affected.
+This can be done using [`mix-blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode). [^blend-mode]   
+There are also ways to do it without user interaction such as by abusing render timings.
+This works because it takes time to paint links a different color. [^render-timings]  
 A PoC was provided on a chromium report that works by using multiple links to increase the time difference. [^render-timings-bug]
-{{< hint info >}} [^leak-1] shows an example of this attack using a whack a mole game to trick the user into clicking areas of the page, multiple bugs were reported about this issue: [^bug-1](https://bugs.chromium.org/p/chromium/issues/detail?id=712246), [^bug-2](https://bugs.chromium.org/p/chromium/issues/detail?id=713521), [^bug-3](https://bugzilla.mozilla.org/show_bug.cgi?id=147777){{< /hint >}}
+{{< hint info >}} [^leak-1] shows an example of this attack using a whack a mole game to trick the user into clicking areas of the page.
+Multiple bugs were reported about this issue: [^bug-1](https://bugs.chromium.org/p/chromium/issues/detail?id=712246), [^bug-2](https://bugs.chromium.org/p/chromium/issues/detail?id=713521), [^bug-3](https://bugzilla.mozilla.org/show_bug.cgi?id=147777){{< /hint >}}
 
 ## Evil Captcha
 Using CSS, it’s possible to take an embed out of context.  
 An example of this is pretending it’s a captcha as seen in [^leak-2]  
 This works by setting the width and hight of an embed so that only the target characters are shown,
-this may use multiple embeds to change the order of the characters being displayed so that its harder for a user to know what infomation there providing.
+this may use multiple embeds to change the order of the characters being displayed so that its harder for a user to know what infomation they're providing.
 
 ## Abusing autocomplete
-If a website uses text inputs and does not opt-out of [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) using ```autocomplete="off"``` it may be possible to leak data such as email addresses. By tricking the user into pressing the keys to navigate the autocomplete ui for a javascript focused text input.
-For chrome this requires the user to be tricked into pressing the Up or Down arrow key which opens the dialog and selects a value then by pressing Enter or Tab the value gets inserted into the page.
+If a website uses text inputs and does not opt-out of [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) using ```autocomplete="off"``` it may be possible to leak data such as email addresses by tricking the user into pressing the keys to navigate the autocomplete UI for a javascript focused text input.
+For Chrome, this requires the user to be tricked into pressing the Up or Down arrow key which opens the dialog and selects a value, then by pressing Enter or Tab the value gets inserted into the page.
 ```javascript
 let input = document.createElement("input");
 input.type = "email";
@@ -60,8 +63,7 @@ setInterval(() => {
 ```
 
 ## Custom cursor
-Might not leak data directly but it may help trick the user,
-as a large cursor may overlay the autocomplete dialog and other native ui.
+A custom cursor might not leak data directly but it may help trick the user, as a large cursor may overlay the autocomplete dialog and other native UI.
 ```html
 <style>
 :root {
@@ -71,8 +73,9 @@ as a large cursor may overlay the autocomplete dialog and other native ui.
 ```
 
 ## Defense
-XFO prevents embeds from being attacked because theres no visual difference as the content does not get shown,
-The *Retrieving user's history* attack can be only prevented by the user. It can be done by disabling the browser history, or if on Firefox, by setting the option `layout.css.visited_links_enabled` to `false` in `about:config` panel.  
+[XFO]({{< ref "/docs/defenses/opt-in/xfo.md" >}}) prevents embeds from being attacked because there's no visual difference as the content does not get shown.
+The *Retrieving user's history* attack can only be prevented by the user.
+This can be done by disabling the browser history, or if on Firefox, by setting the option `layout.css.visited_links_enabled` to `false` in `about:config` panel.  
 | [SameSite Cookies (Lax)]({{< ref "/docs/defenses/opt-in/same-site-cookies.md" >}}) | [COOP]({{< ref "/docs/defenses/opt-in/coop.md" >}}) | [Framing Protections]({{< ref "/docs/defenses/opt-in/xfo.md" >}}) |                  [Isolation Policies]({{< ref "/docs/defenses/isolation-policies" >}})                   |
 | :--------------------------------------------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------: |
 |                                         ❌                                          |                          ❌                          |                                 ✔️                                 | ❌  |

--- a/content/docs/attacks/frame-counting.md
+++ b/content/docs/attacks/frame-counting.md
@@ -77,7 +77,7 @@ Some examples of frame counting attacks are:
 
 A vulnerability reported to Facebook used this technique to leak user-related information such as specific content published in posts, religious information about friends, or photo locations[^1].
 
-A vulnerability reported to GitHub showcase how your private repositories could have been exposed[^2].
+A vulnerability on GitHub demonstrates how private repositories could have been exposed using this technique as well.[^2].
 
 ## References
 

--- a/content/docs/contributions/_index.md
+++ b/content/docs/contributions/_index.md
@@ -88,7 +88,7 @@ We would like to thank the following users who [contributed](https://github.com/
 [NDevTK](https://github.com/NDevTK), [1lastBr3ath](https://twitter.com/1lastBr3ath),
 [Brasco](https://github.com/Brasco/), [rick.titor](https://github.com/riccardomerlano),
 [Chris Fredrickson](https://github.com/cfredric/), [jub0bs](https://github.com/jub0bs),
-[Zeyu (Zayne) Zhang](https://github.com/zeyu2001)
+[Zeyu (Zayne) Zhang](https://github.com/zeyu2001), [Medi](https://twitter.com/medi_0ne)
 
 In addition, we would also like to acknowledge the users who [contributed](https://github.com/xsleaks/xsleaks/wiki/Browser-Side-Channels/_history) to the predecessor of the current XS-Leaks wiki:
 


### PR DESCRIPTION
Hi,

I've made an update to the **frame-counting.md** file, adding a new example that discusses a blog post I recently published. The example illustrates how cross-site frame counting can potentially expose private repositories on GitHub. I'm excited about the opportunity to contribute to your repository, especially since I've gained valuable insights from it.

Thank you for your dedicated work!