### PR TITLE
fix: small typo

### DIFF
--- a/content/docs/attacks/css-injection.md
+++ b/content/docs/attacks/css-injection.md
@@ -26,7 +26,7 @@ Larger text dimensions can result in the scroll bar being shown,
 This scroll bar can have a custom style such as `background: url()` so that it makes a request to an attacker-controlled server when shown. [^3]
 
 ## Defense
-- Put attacker controled content in its own document this can be done using a iframe with the srcdoc attrbute.
+- Put attacker controled content in its own document this can be done using a iframe with the srcdoc attribute.
 Optionaly include the sandbox attbute to isolate the content into its own origin.
 - Use a CSS inliner so global styles get converted.
 


### PR DESCRIPTION
Quick typo fix of `attribute`.