### PR TITLE
Hidden download detection

### DIFF
--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -35,7 +35,7 @@ To detect if any kind of navigation occurred, an attacker can:
 
 When an endpoint sets the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header, it instructs the browser to download the response as an attachment instead of navigating to it. Detecting if this behavior occurred might allow attackers to leak private information if the outcome depends on the state of the victim's account.
 
-### Download Navigation (without Lax cookies)
+### Download Navigation (with iframes)
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
@@ -71,7 +71,7 @@ When there is no navigation inside an `iframe` caused by a download attempt, the
 This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), because the `X-Frame-Options` and `Content-Security-Policy` headers are ignored if `Content-Disposition: attachment` is specified.
 {{< /hint >}}
 
-### Download Navigation (with Lax cookies)
+### Download Navigation (without iframes)
 
 A variation of the technique presented in the previous section can also be effectively tested using `window` objects:
 

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -73,7 +73,7 @@ This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), be
 
 ### Download Navigation (without iframes)
 
-A variation of the technique presented in the previous section can also be effectively tested using `window` objects, this also uses a sandboxed iframe to prevent a visable file download:
+A variation of the technique presented in the previous section can also be effectively tested using `window` objects, this also uses a sandboxed iframe to prevent a visible file download or prompt:
 
 ```javascript
 // Set the destination URL

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -73,7 +73,7 @@ This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), be
 
 ### Download Navigation (without iframes)
 
-A variation of the technique presented in the previous section can also be effectively tested using `window` objects:
+A variation of the technique presented in the previous section can also be effectively tested using `window` objects, this also uses a sandboxed iframe to prevent a visable file download:
 
 ```javascript
 // Set the destination URL

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -71,6 +71,8 @@ The following snippet can be used to detect whether such a navigation has occurr
 var url = 'https://example.org/';
 // Create an outer iframe to measure onload event
 var iframe = document.createElement('iframe');
+// Don't actually download the file to be stealthy
+iframe.sandbox = 'allow-scripts allow-same-origin';
 document.body.appendChild(iframe);
 // Create an inner iframe to test for the download attempt
 iframe.srcdoc = `<iframe src="${url}" ></iframe>`;

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -35,7 +35,7 @@ To detect if any kind of navigation occurred, an attacker can:
 
 When an endpoint sets the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header, it instructs the browser to download the response as an attachment instead of navigating to it. Detecting if this behavior occurred might allow attackers to leak private information if the outcome depends on the state of the victim's account.
 
-### Download Navigation (without Lax cookies)
+### Download Navigation (with iframes)
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
@@ -47,7 +47,8 @@ var url = 'https://example.org/';
 // Create an outer iframe to measure onload event
 var iframe = document.createElement('iframe');
 // Don't actually download the file to be stealthy
-iframe.sandbox = 'allow-scripts allow-same-origin';
+// Using window.open from this sandbox will also not download the file.
+iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
 document.body.appendChild(iframe);
 // Create an inner iframe to test for the download attempt
 iframe.srcdoc = `<iframe src="${url}" ></iframe>`;
@@ -71,7 +72,7 @@ When there is no navigation inside an `iframe` caused by a download attempt, the
 This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), because the `X-Frame-Options` and `Content-Security-Policy` headers are ignored if `Content-Disposition: attachment` is specified.
 {{< /hint >}}
 
-### Download Navigation (with Lax cookies)
+### Download Navigation (without iframes)
 
 A variation of the technique presented in the previous section can also be effectively tested using `window` objects:
 
@@ -79,14 +80,8 @@ A variation of the technique presented in the previous section can also be effec
 // Set the destination URL
 var url = 'https://example.org';
 
-// Don't actually download the file to be stealthy
-var iframe = document.createElement('iframe');
-iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
-document.body.appendChild(iframe);
-var openSandboxed = iframe.contentWindow.open;
-
 // Get a window reference
-var win = window.openSandboxed(url);
+var win = window.open(url);
 
 // Wait for the window to load.
 setTimeout(() => {

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -60,7 +60,7 @@ setTimeout(() => {
 This attack is only possible in Chromium-based browsers with automatic downloads enabled. In addition, the attack can't be repeated since the user needs to close the download bar for it to be measurable again.
 {{< /hint >}}
 
-### Download Navigation (with iframes)
+### Download Navigation (without Lax cookies)
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
@@ -96,15 +96,22 @@ When there is no navigation inside an `iframe` caused by a download attempt, the
 This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), because the `X-Frame-Options` and `Content-Security-Policy` headers are ignored if `Content-Disposition: attachment` is specified.
 {{< /hint >}}
 
-### Download Navigation (without iframes)
+### Download Navigation (with Lax cookies)
 
 A variation of the technique presented in the previous section can also be effectively tested using `window` objects:
 
 ```javascript
 // Set the destination URL
 var url = 'https://example.org';
+
+// Don't actually download the file to be stealthy
+var iframe = document.createElement('iframe');
+iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
+document.body.appendChild(iframe);
+openSandboxed = iframe.contentWindow.open;
+
 // Get a window reference
-var win = window.open(url);
+var win = window.openSandboxed(url);
 
 // Wait for the window to load.
 setTimeout(() => {

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -79,7 +79,6 @@ A variation of the technique presented in the previous section can also be effec
 ```javascript
 // Set the destination URL
 var url = 'https://example.org';
-
 // Get a window reference
 var win = window.open(url);
 

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -39,7 +39,7 @@ When an endpoint sets the [`Content-Disposition: attachment`](https://developer.
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
-In the snippet below , we've added a sandboxed iframe with downloads disabled to prevent downloading modal from appearing. 
+In the snippet below , we've added a sandboxed iframe with downloads disabled to prevent a download modal from appearing. 
 
 ```javascript
 // Set the destination URL to test for the download attempt
@@ -73,7 +73,7 @@ This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), be
 
 ### Download Navigation (without iframes)
 
-A variation of the technique presented in the previous section can also be effectively tested using `window` objects. In the snippet below, we've added a sandboxed iframe with disabled downloads to prevent downloading modal from appearing.
+A variation of the technique presented in the previous section can also be effectively tested using `window` objects. In the snippet below, we've added a sandboxed iframe with disabled downloads to prevent a download modal from appearing.
 
 ```javascript
 // Set the destination URL

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -35,7 +35,7 @@ To detect if any kind of navigation occurred, an attacker can:
 
 When an endpoint sets the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header, it instructs the browser to download the response as an attachment instead of navigating to it. Detecting if this behavior occurred might allow attackers to leak private information if the outcome depends on the state of the victim's account.
 
-### Download Navigation (with iframes)
+### Download Navigation (without Lax cookies)
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
@@ -47,7 +47,6 @@ var url = 'https://example.org/';
 // Create an outer iframe to measure onload event
 var iframe = document.createElement('iframe');
 // Don't actually download the file to be stealthy
-// Using window.open from this sandbox will also not download the file.
 iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
 document.body.appendChild(iframe);
 // Create an inner iframe to test for the download attempt
@@ -72,15 +71,21 @@ When there is no navigation inside an `iframe` caused by a download attempt, the
 This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), because the `X-Frame-Options` and `Content-Security-Policy` headers are ignored if `Content-Disposition: attachment` is specified.
 {{< /hint >}}
 
-### Download Navigation (without iframes)
+### Download Navigation (with Lax cookies)
 
 A variation of the technique presented in the previous section can also be effectively tested using `window` objects:
 
 ```javascript
 // Set the destination URL
 var url = 'https://example.org';
+
+// Don't actually download the file to be stealthy
+var iframe = document.createElement('iframe');
+iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
+document.body.appendChild(iframe);
+
 // Get a window reference
-var win = window.open(url);
+var win = iframe.contentWindow.open(url);
 
 // Wait for the window to load.
 setTimeout(() => {

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -83,7 +83,7 @@ var url = 'https://example.org';
 var iframe = document.createElement('iframe');
 iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
 document.body.appendChild(iframe);
-openSandboxed = iframe.contentWindow.open;
+var openSandboxed = iframe.contentWindow.open;
 
 // Get a window reference
 var win = window.openSandboxed(url);

--- a/content/docs/attacks/navigations.md
+++ b/content/docs/attacks/navigations.md
@@ -39,7 +39,7 @@ When an endpoint sets the [`Content-Disposition: attachment`](https://developer.
 
 Another way to test for the [`Content-Disposition: attachment`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header is to check if a navigation occurred. If a page load causes a download, it does not trigger a navigation and the window stays within the same origin. [Run demo](https://xsinator.com/testing.html#Download%20Detection)
 
-The following snippet can be used to detect whether such a navigation has occurred and therefore detect a download attempt:
+In the snippet below , we've added a sandboxed iframe with downloads disabled to prevent downloading modal from appearing. 
 
 ```javascript
 // Set the destination URL to test for the download attempt
@@ -73,7 +73,7 @@ This attack works regardless of any [Framing Protections]({{< ref "xfo" >}}), be
 
 ### Download Navigation (without iframes)
 
-A variation of the technique presented in the previous section can also be effectively tested using `window` objects, this also uses a sandboxed iframe to prevent a visible file download or prompt:
+A variation of the technique presented in the previous section can also be effectively tested using `window` objects. In the snippet below, we've added a sandboxed iframe with disabled downloads to prevent downloading modal from appearing.
 
 ```javascript
 // Set the destination URL


### PR DESCRIPTION
Adds sandbox to `Download Navigation (with iframes)`  to prevent a download, with comment about using `window.open` inside it.