### PR TITLE
Remove NIP as a CORB XS-Leak mitigation

### DIFF
--- a/content/docs/attacks/browser-features/corb.md
+++ b/content/docs/attacks/browser-features/corb.md
@@ -52,9 +52,8 @@ CORB can also allow attackers to detect when the `nosniff` header is present in 
 
 | [SameSite Cookies (Lax)]({{< ref "/docs/defenses/opt-in/same-site-cookies.md" >}}) | [COOP]({{< ref "/docs/defenses/opt-in/coop.md" >}}) | [Framing Protections]({{< ref "/docs/defenses/opt-in/xfo.md" >}}) |                                          [Isolation Policies]({{< ref "/docs/defenses/isolation-policies" >}})                                          |
 | :--------------------------------------------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------: |
-|                                         ✔️                                          |                          ❌                          |                                 ❌                                 | [RIP]({{< ref "/docs/defenses/isolation-policies/resource-isolation" >}}) 🔗 [NIP]({{< ref "/docs/defenses/isolation-policies/navigation-isolation" >}}) |
+|                                         ✔️                                          |                          ❌                          |                                 ❌                                 | [RIP]({{< ref "/docs/defenses/isolation-policies/resource-isolation" >}}) |
 
-🔗 – Defense mechanisms must be combined to be effective against different scenarios.
 
 {{< hint tip >}}
 Developers can deploy [CORP]({{< ref "/docs/defenses/opt-in/corp.md" >}}) in an application's subresources to force a protection similar to CORB that does not inspect responses to decide when to act. To prevent attackers from abusing this XS-Leak, generic XS-Leaks defense mechanisms are also effective.


### PR DESCRIPTION
According to the CORB explainer [1], navigational requests are exempt from CORB. Therefore, the presence of a NIP is irrelevant since, even if there is no NIP, it is not possible to distinguish navigational requests based on interactions with the CORB.


[1] - [https://chromium.googlesource.com/chromium/src/+/926617b5a55ded064f11e2f71308cd26fc4f6bf4/content/browser/loader/cross_origin_read_blocking_explainer.md#what-kinds-of-requests-are-corb_eligible](https://chromium.googlesource.com/chromium/src/+/926617b5a55ded064f11e2f71308cd26fc4f6bf4/content/browser/loader/cross_origin_read_blocking_explainer.md#what-kinds-of-requests-are-corb_eligible)