### PR TITLE
Remove NIP as a CORP XS-Leak mitigation

### DIFF
--- a/content/docs/attacks/browser-features/corp.md
+++ b/content/docs/attacks/browser-features/corp.md
@@ -26,6 +26,4 @@ An application can avoid this XS-Leak if it guarantees `CORP` is deployed in all
 
 | [SameSite Cookies (Lax)]({{< ref "/docs/defenses/opt-in/same-site-cookies.md" >}}) | [COOP]({{< ref "/docs/defenses/opt-in/coop.md" >}}) | [Framing Protections]({{< ref "/docs/defenses/opt-in/xfo.md" >}}) |                                          [Isolation Policies]({{< ref "/docs/defenses/isolation-policies" >}})                                          |
 | :--------------------------------------------------------------------------------: | :-------------------------------------------------: | :---------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------: |
-|                                         ✔️                                          |                          ❌                          |                                 ❌                                 | [RIP]({{< ref "/docs/defenses/isolation-policies/resource-isolation" >}}) 🔗 [NIP]({{< ref "/docs/defenses/isolation-policies/navigation-isolation" >}}) |
-
-🔗 – Defense mechanisms must be combined to be effective against different scenarios.
+|                                         ✔️                                          |                          ❌                          |                                 ❌                                 | [RIP]({{< ref "/docs/defenses/isolation-policies/resource-isolation" >}}) |


### PR DESCRIPTION
Here [1] is stated that "CORP does not protect against navigational requests.". If this is the case, the presence of a NIP would not impact CORP-based XS-leaks since it is not possible to distinguish navigational requests based on interactions with the CORP.


[1] - [https://xsleaks.dev/docs/defenses/opt-in/corp/](https://xsleaks.dev/docs/defenses/opt-in/corp/)